### PR TITLE
Adding missing onRollStart method to the API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,18 @@ Events:
       let accZ = xyzAccRaw[2];
   };
 ```   
+
+
+ ```javascript 
+ /**
+  * When the die has started rolling the function "onRollStart" will be called from the GoDice class with the following parameter:
+  * @param {string} diceId - the die unique identifier	 
+  */
+  
+  // example:
+  
+  GoDice.prototype.onRollStart = (diceId) => {
+      // die unique identifier
+      let dieIdentifier = diceID;
+  };
+```   


### PR DESCRIPTION
Added some documentation for the onRollStart method in the events section of the API based off of the existing documentation.