### PR TITLE
Fixing duplicate dice-wrapper elements on same die connect

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,6 +30,11 @@ GoDice.prototype.onDiceConnected = (diceId, diceInstance) => {
 	// get new die element or it's instance if it's already exists
 	const diceHtmlEl = getDiceHtmlEl(diceId);
 
+	// clear existing die element content if it exists
+    while (diceHtmlEl.firstChild) {
+        diceHtmlEl.removeChild(diceHtmlEl.lastChild);
+    }
+
 	// get die host from html, where we will put our connected dices
 	const diceHost = document.getElementById("dice-host");
 


### PR DESCRIPTION
Could fix the issue by making `onDiceConnected` a no-op if the die already has a dice-wrapper, or by clearing all of the children  of the dice-wrapper.  Since there is already logic in `getDiceHtmlEl` to check if the dice-wrapper element exists I thought it would be better to clear the elements instead of duplicating/refactoring the logic.